### PR TITLE
Add .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+xcuserdata/
+
+.build/
+LineNoise.xcodeproj/
+Package.resolved


### PR DESCRIPTION
This contains entries for the files that Swift Package Manager creates,
plus the usual macOS / Xcode ones.