### PR TITLE
Remove use of String.characters.

### DIFF
--- a/Sources/linenoise/EditState.swift
+++ b/Sources/linenoise/EditState.swift
@@ -107,7 +107,7 @@ internal class EditState {
     }
     
     func deleteCharacter() -> Bool {
-        if location >= currentBuffer.endIndex || currentBuffer.characters.count == 0 {
+        if location >= currentBuffer.endIndex || currentBuffer.isEmpty {
             return false
         }
         
@@ -133,12 +133,12 @@ internal class EditState {
         let oldLocation = location
         
         // Go backwards to find the first non space character
-        while location > buffer.startIndex && buffer.characters[buffer.index(before: location)] == " " {
+        while location > buffer.startIndex && buffer[buffer.index(before: location)] == " " {
             location = buffer.index(before: location)
         }
         
         // Go backwards to find the next space character (start of the word)
-        while location > buffer.startIndex && buffer.characters[buffer.index(before: location)] != " " {
+        while location > buffer.startIndex && buffer[buffer.index(before: location)] != " " {
             location = buffer.index(before: location)
         }
         
@@ -152,11 +152,11 @@ internal class EditState {
     }
     
     func deleteToEndOfLine() -> Bool {
-        if location == buffer.endIndex || buffer.characters.count == 0 {
+        if location == buffer.endIndex || buffer.isEmpty {
             return false
         }
         
-        buffer.removeLast(buffer.characters.count - cursorPosition)
+        buffer.removeLast(buffer.count - cursorPosition)
         return true
     }
     

--- a/Sources/linenoise/linenoise.swift
+++ b/Sources/linenoise/linenoise.swift
@@ -439,12 +439,12 @@ public class LineNoise {
                 return ""
             }
             
-            let currentLineLength = editState.prompt.characters.count + editState.currentBuffer.characters.count
+            let currentLineLength = editState.prompt.count + editState.currentBuffer.count
             
             let numCols = getNumCols()
             
             // Don't display the hint if it won't fit.
-            if hint.characters.count + currentLineLength > numCols {
+            if hint.count + currentLineLength > numCols {
                 return ""
             }
             


### PR DESCRIPTION
String.characters is deprecated as of Swift 4.0.2 / Xcode 9.1.  Remove
all uses of it in favor of working directly with the String.