### PR TITLE
Add an option to preserve user edits to history.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Implemented in pure Swift, with a Swifty API, this library is easy to embed in p
     + [Limit the Number of Items in History](#limit-the-number-of-items-in-history)
     + [Saving the History to a File](#saving-the-history-to-a-file)
     + [Loading History From a File](#loading-history-from-a-file)
+    + [History Editing Behavior](#history-editing-behavior)
   * [Completion](#completion)
   * [Hints](#hints)
 - [Acknowledgements](#acknowledgements)
@@ -79,6 +80,12 @@ ln.saveHistory(toFile: "/tmp/history.txt")
 This will add all of the items from the file to the current history
 ```swift
 ln.loadHistory(fromFile: "/tmp/history.txt")
+```
+
+### History Editing Behavior
+By default, any edits by the user to a line in the history will be discarded if the user moves forward or back in the history without pressing Enter.  If you prefer to have all edits preserved, then use the following:
+```swift
+ln.preserveHistoryEdits = true
 ```
 
 ## Completion

--- a/Sources/linenoise/History.swift
+++ b/Sources/linenoise/History.swift
@@ -74,6 +74,10 @@ internal class History {
         // Reset the history pointer to the end index
         index = history.endIndex
     }
+
+    func replaceCurrent(_ item: String) {
+        history[index] = item
+    }
     
     // MARK: - History Navigation
     

--- a/Sources/linenoise/linenoise.swift
+++ b/Sources/linenoise/linenoise.swift
@@ -44,6 +44,13 @@ public class LineNoise {
 
     public let mode: Mode
 
+    /**
+     If false (the default) any edits by the user to a line in the history
+     will be discarded if the user moves forward or back in the history
+     without pressing Enter.  If true, all history edits will be preserved.
+     */
+    public var preserveHistoryEdits = false
+
     var history: History = History()
     
     var completionCallback: ((String) -> ([String]))?
@@ -419,6 +426,9 @@ public class LineNoise {
         // push it into a temporary buffer so it can be retreived later.
         if history.currentIndex == history.historyItems.count {
             tempBuf = editState.currentBuffer
+        }
+        else if preserveHistoryEdits {
+            history.replaceCurrent(editState.currentBuffer)
         }
         
         if let historyItem = history.navigateHistory(direction: direction) {


### PR DESCRIPTION
This adds a new flag, LineNoise.preserveHistoryEdits.  The default is
to follow existing behavior, which is that any edits by the user to a
line in the history will be discarded if the user moves forward or back
in the history without pressing Enter.  Setting this flag to true, will
cause all history edits will be preserved, even if the user is just
moving backwards and forwards in the history.  This matches bash's
(presumably readline's) behavior.