### PR TITLE
Bugfix history navigation after adding duplicate lines

### DIFF
--- a/Sources/linenoise/History.swift
+++ b/Sources/linenoise/History.swift
@@ -60,6 +60,8 @@ internal class History {
         // Don't add a duplicate if the last item is equal to this one
         if let lastItem = history.last {
             if lastItem == item {
+                // Reset the history pointer to the end index
+                index = history.endIndex
                 return
             }
         }

--- a/Tests/linenoiseTests/HistoryTests.swift
+++ b/Tests/linenoiseTests/HistoryTests.swift
@@ -127,6 +127,18 @@ class HistoryTests: XCTestCase {
         expect(h.navigateHistory(direction: .next)).to(beNil())
     }
     
+    func testHistoryNavigationAfterAddingDuplicateLines() {
+        let h = History()
+        h.add("1")
+        h.add("2")
+        
+        expect(h.navigateHistory(direction: .previous)).to(equal("2"))
+        h.add("2")
+        
+        expect(h.navigateHistory(direction: .previous)).to(equal("2"))
+        expect(h.navigateHistory(direction: .previous)).to(equal("1"))
+    }
+    
     // MARK: - Saving and Loading
     
     func testHistorySavesToFile() {
@@ -204,6 +216,7 @@ class HistoryTests: XCTestCase {
                 ("testHistoryNavigationReturnsSingleItemWhenHistoryHasOneItem", testHistoryNavigationReturnsSingleItemWhenHistoryHasOneItem),
                 ("testHistoryStopsAtBeginning", testHistoryStopsAtBeginning),
                 ("testHistoryNavigationStopsAtEnd", testHistoryNavigationStopsAtEnd),
+                ("testHistoryNavigationAfterAddingDuplicateLines", testHistoryNavigationAfterAddingDuplicateLines),
                 ("testHistorySavesToFile", testHistorySavesToFile),
                 ("testHistoryLoadsFromFile", testHistoryLoadsFromFile),
                 ("testHistoryLoadingRespectsMaxLength", testHistoryLoadingRespectsMaxLength)


### PR DESCRIPTION
This fixes a small bug caused by the history index not always being reset.

So a user could go through a session like this:
```
> 1    # user typed 1, then enter
> 2    # user typed 2, then enter
> 2    # user pressed key-up, then enter
> 1    # user pressed key-up again and expected 2 but this time the history index was off
```