### PR TITLE
Detect when we're running from within Xcode and mark terminal type as unsupported

### DIFF
--- a/Sources/linenoise/linenoise.swift
+++ b/Sources/linenoise/linenoise.swift
@@ -178,6 +178,7 @@ public class LineNoise {
     // MARK: - Terminal handling
     
     private static func isUnsupportedTerm(_ term: String) -> Bool {
+        guard ProcessInfo.processInfo.environment["XPC_SERVICE_NAME"] == nil else { return true }
         return ["", "dumb", "cons25", "emacs"].contains(term)
     }
     

--- a/Sources/linenoise/linenoise.swift
+++ b/Sources/linenoise/linenoise.swift
@@ -178,7 +178,11 @@ public class LineNoise {
     // MARK: - Terminal handling
     
     private static func isUnsupportedTerm(_ term: String) -> Bool {
-        guard ProcessInfo.processInfo.environment["XPC_SERVICE_NAME"] == nil else { return true }
+        #if os(macOS)
+        if let xpcServiceName = ProcessInfo.processInfo.environment["XPC_SERVICE_NAME"], xpcServiceName.localizedCaseInsensitiveContains("com.apple.dt.xcode") {
+            return true
+        }
+        #endif
         return ["", "dumb", "cons25", "emacs"].contains(term)
     }
     


### PR DESCRIPTION
Fixes https://github.com/andybest/linenoise-swift/issues/16