### PR TITLE
Add UTF-8 support

### DIFF
--- a/Sources/linenoise/ControlCharacters.swift
+++ b/Sources/linenoise/ControlCharacters.swift
@@ -52,6 +52,6 @@ internal enum ControlCharacters: UInt8 {
     case Backspace  = 127
     
     var character: Character {
-        return Character(UnicodeScalar(Int(self.rawValue))!)
+        return Character(UnicodeScalar(self.rawValue))
     }
 }

--- a/Sources/linenoise/EditState.swift
+++ b/Sources/linenoise/EditState.swift
@@ -30,12 +30,13 @@
 import Foundation
 
 internal class EditState {
-    var buffer: String = ""
-    var location: String.Index
+    var buffer: [Character] = []
+    var location: Int
     let prompt: String
     
-    public var currentBuffer: String {
-        return buffer
+    public var text: String {
+        get { buffer.string }
+        set { buffer = newValue.characters }
     }
     
     init(prompt: String) {
@@ -44,7 +45,10 @@ internal class EditState {
     }
     
     var cursorPosition: Int {
-        return buffer.distance(from: buffer.startIndex, to: location)
+        // terminal seems to treat non-ASCII characters as if they take two positions.
+        buffer[buffer.startIndex..<location].reduce(0) {
+            $0 + ($1.isASCII ? 1 : 2)
+        }
     }
     
     func insertCharacter(_ char: Character) {
@@ -107,7 +111,7 @@ internal class EditState {
     }
     
     func deleteCharacter() -> Bool {
-        if location >= currentBuffer.endIndex || currentBuffer.isEmpty {
+        if location >= buffer.endIndex || buffer.isEmpty {
             return false
         }
         

--- a/Sources/linenoise/linenoise.swift
+++ b/Sources/linenoise/linenoise.swift
@@ -34,6 +34,23 @@
 #endif
 import Foundation
 
+extension StringProtocol {
+    var characters: [Character] {
+        self.map { $0 }
+    }
+}
+
+extension ArraySlice<Character> {
+    var string: String {
+        self.reduce("") { $0 + String($1) }
+    }
+}
+
+extension Array<Character> {
+    var string: String {
+        self.reduce("") { $0 + String($1) }
+    }
+}
 
 public class LineNoise {
     public enum Mode {

--- a/Tests/linenoiseTests/EditStateTests.swift
+++ b/Tests/linenoiseTests/EditStateTests.swift
@@ -35,27 +35,27 @@ class EditStateTests: XCTestCase {
     
     func testInitEmptyBuffer() {
         let s = EditState(prompt: "$ ")
-        expect(s.currentBuffer).to(equal(""))
-        expect(s.location).to(equal(s.currentBuffer.startIndex))
+        expect(s.text).to(equal(""))
+        expect(s.location).to(equal(s.buffer.startIndex))
         expect(s.prompt).to(equal("$ "))
     }
     
     func testInsertCharacter() {
         let s = EditState(prompt: "")
-        s.insertCharacter("A"["A".startIndex])
+        s.insertCharacter("A")
         
-        expect(s.buffer).to(equal("A"))
-        expect(s.location).to(equal(s.currentBuffer.endIndex))
+        expect(s.text).to(equal("A"))
+        expect(s.location).to(equal(s.buffer.endIndex))
         expect(s.cursorPosition).to(equal(1))
     }
     
     func testBackspace() {
         let s = EditState(prompt: "")
-        s.insertCharacter("A"["A".startIndex])
+        s.insertCharacter("A")
         
         expect(s.backspace()).to(beTrue())
-        expect(s.currentBuffer).to(equal(""))
-        expect(s.location).to(equal(s.currentBuffer.startIndex))
+        expect(s.text).to(equal(""))
+        expect(s.location).to(equal(s.buffer.startIndex))
         
         // No more characters left, so backspace should return false
         expect(s.backspace()).to(beFalse())
@@ -63,32 +63,32 @@ class EditStateTests: XCTestCase {
     
     func testMoveLeft() {
         let s = EditState(prompt: "")
-        s.buffer = "Hello"
-        s.location = s.currentBuffer.endIndex
+        s.text = "Hello"
+        s.location = s.buffer.endIndex
         
         expect(s.moveLeft()).to(beTrue())
         expect(s.cursorPosition).to(equal(4))
         
-        s.location = s.currentBuffer.startIndex
+        s.location = s.buffer.startIndex
         expect(s.moveLeft()).to(beFalse())
     }
     
     func testMoveRight() {
         let s = EditState(prompt: "")
-        s.buffer = "Hello"
-        s.location = s.currentBuffer.startIndex
+        s.text = "Hello"
+        s.location = s.buffer.startIndex
         
         expect(s.moveRight()).to(beTrue())
         expect(s.cursorPosition).to(equal(1))
         
-        s.location = s.currentBuffer.endIndex
+        s.location = s.buffer.endIndex
         expect(s.moveRight()).to(beFalse())
     }
     
     func testMoveHome() {
         let s = EditState(prompt: "")
-        s.buffer = "Hello"
-        s.location = s.currentBuffer.endIndex
+        s.text = "Hello"
+        s.location = s.buffer.endIndex
         
         expect(s.moveHome()).to(beTrue())
         expect(s.cursorPosition).to(equal(0))
@@ -98,8 +98,8 @@ class EditStateTests: XCTestCase {
     
     func testMoveEnd() {
         let s = EditState(prompt: "")
-        s.buffer = "Hello"
-        s.location = s.currentBuffer.startIndex
+        s.text = "Hello"
+        s.location = s.buffer.startIndex
         
         expect(s.moveEnd()).to(beTrue())
         expect(s.cursorPosition).to(equal(5))
@@ -109,95 +109,95 @@ class EditStateTests: XCTestCase {
     
     func testRemovePreviousWord() {
         let s = EditState(prompt: "")
-        s.buffer = "Hello world"
-        s.location = s.currentBuffer.endIndex
+        s.text = "Hello world"
+        s.location = s.buffer.endIndex
         
         expect(s.deletePreviousWord()).to(beTrue())
-        expect(s.buffer).to(equal("Hello "))
-        expect(s.location).to(equal("Hello ".endIndex))
+        expect(s.text).to(equal("Hello "))
+        expect(s.location).to(equal(s.buffer.endIndex))
         
-        s.buffer = ""
-        s.location = s.currentBuffer.endIndex
+        s.buffer = []
+        s.location = s.buffer.endIndex
         
         expect(s.deletePreviousWord()).to(beFalse())
         
         // Test with cursor location in the middle of the text
-        s.buffer = "This is a test"
-        s.location = s.currentBuffer.index(s.currentBuffer.startIndex, offsetBy: 8)
+        s.text = "This is a test"
+        s.location = s.buffer.index(s.buffer.startIndex, offsetBy: 8)
         
         expect(s.deletePreviousWord()).to(beTrue())
-        expect(s.buffer).to(equal("This a test"))
+        expect(s.text).to(equal("This a test"))
     }
     
     func testDeleteToEndOfLine() {
         let s = EditState(prompt: "")
-        s.buffer = "Hello world"
-        s.location = s.currentBuffer.endIndex
+        s.text = "Hello world"
+        s.location = s.buffer.endIndex
         
         expect(s.deleteToEndOfLine()).to(beFalse())
         
-        s.location = s.currentBuffer.index(s.currentBuffer.startIndex, offsetBy: 5)
+        s.location = s.buffer.index(s.buffer.startIndex, offsetBy: 5)
         
         expect(s.deleteToEndOfLine()).to(beTrue())
-        expect(s.currentBuffer).to(equal("Hello"))
+        expect(s.text).to(equal("Hello"))
     }
     
     func testDeleteCharacter() {
         let s = EditState(prompt: "")
-        s.buffer = "Hello world"
-        s.location = s.currentBuffer.endIndex
+        s.text = "Hello world"
+        s.location = s.buffer.endIndex
         
         expect(s.deleteCharacter()).to(beFalse())
         
-        s.location = s.currentBuffer.startIndex
+        s.location = s.buffer.startIndex
         
         expect(s.deleteCharacter()).to(beTrue())
-        expect(s.currentBuffer).to(equal("ello world"))
+        expect(s.text).to(equal("ello world"))
         
-        s.location = s.currentBuffer.index(s.currentBuffer.startIndex, offsetBy: 5)
+        s.location = s.buffer.index(s.buffer.startIndex, offsetBy: 5)
         
         expect(s.deleteCharacter()).to(beTrue())
-        expect(s.currentBuffer).to(equal("ello orld"))
+        expect(s.text).to(equal("ello orld"))
     }
     
     func testEraseCharacterRight() {
         let s = EditState(prompt: "")
-        s.buffer = "Hello"
-        s.location = s.currentBuffer.endIndex
+        s.text = "Hello"
+        s.location = s.buffer.endIndex
         
         expect(s.eraseCharacterRight()).to(beFalse())
         
-        s.location = s.currentBuffer.startIndex
+        s.location = s.buffer.startIndex
         expect (s.eraseCharacterRight()).to(beTrue())
-        expect(s.currentBuffer).to(equal("ello"))
+        expect(s.text).to(equal("ello"))
         
         // Test empty buffer
-        s.buffer = ""
-        s.location = s.currentBuffer.startIndex
+        s.buffer = []
+        s.location = s.buffer.startIndex
         expect(s.eraseCharacterRight()).to(beFalse())
     }
     
     func testSwapCharacters() {
         let s = EditState(prompt: "")
-        s.buffer = "Hello"
-        s.location = s.currentBuffer.endIndex
+        s.text = "Hello"
+        s.location = s.buffer.endIndex
         
         // Cursor at the end of the text
         expect(s.swapCharacterWithPrevious()).to(beTrue())
-        expect(s.currentBuffer).to(equal("Helol"))
-        expect(s.location).to(equal(s.currentBuffer.endIndex))
+        expect(s.text).to(equal("Helol"))
+        expect(s.location).to(equal(s.buffer.endIndex))
         
         // Cursor in the middle of the text
-        s.location = s.currentBuffer.index(before: s.currentBuffer.endIndex)
+        s.location = s.buffer.index(before: s.buffer.endIndex)
         expect(s.swapCharacterWithPrevious()).to(beTrue())
-        expect(s.currentBuffer).to(equal("Hello"))
-        expect(s.location).to(equal(s.currentBuffer.endIndex))
+        expect(s.text).to(equal("Hello"))
+        expect(s.location).to(equal(s.buffer.endIndex))
         
         // Cursor at the start of the text
-        s.location = s.currentBuffer.startIndex
+        s.location = s.buffer.startIndex
         expect(s.swapCharacterWithPrevious()).to(beTrue())
-        expect(s.currentBuffer).to(equal("eHllo"))
-        expect(s.location).to(equal(s.currentBuffer.index(s.currentBuffer.startIndex, offsetBy: 2)))
+        expect(s.text).to(equal("eHllo"))
+        expect(s.location).to(equal(s.buffer.index(s.buffer.startIndex, offsetBy: 2)))
     }
 }
 


### PR DESCRIPTION
This is my attempt to add support for UTF-8 input. This generalizes the reading and writing of characters and strings, using the Character type instead of representing characters as UInt8.

I've tested it on Arch Linux primarily, over SSH and directly using a KDE terminal application. All the unit tests pass, and terminal display and editing seem to work. It's possible with more work to simplify the buffer indexing, since it's now using an internal buffer of [Character] as the intermediate representation. This would allow using Int for character indexing, instead of having to use buffer.startIndex, .endIndex. However, I've left that unchanged for now, as that would be needed when using array slices.